### PR TITLE
Fix argument validation

### DIFF
--- a/lib/vorpal.js
+++ b/lib/vorpal.js
@@ -630,7 +630,7 @@ vorpal._exec = function(item) {
   }
 
   function validateArg(arg, cmdArg) {
-    if (!arg && cmdArg.required === true) {
+    if (arg === undefined && cmdArg.required === true) {
       item.session.log(" ");
       item.session.log("  Missing required argument. Showing Help:");
       item.session.log(match.helpInformation());


### PR DESCRIPTION
Hi,

I am using `vantage` like this

```
vantage.command('seek <num>').action(...)
```

on CLI

```
% seek 1
(works)
% seek 0

    Missing required argument. Showing Help:
    ...
```

I want to fix this. Tanks

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dthree/vorpal/6)
<!-- Reviewable:end -->
