### PR TITLE
Print warning message if user registers an action with duplicate name

### DIFF
--- a/lib/vorpal.js
+++ b/lib/vorpal.js
@@ -262,7 +262,7 @@ vorpal.command = function (name, desc, opts) {
   if (!exists) {
     this.commands.push(cmd);
   } else {
-    console.warn(chalk.red("Warning! Command with name '"+ name + "' was registered more than once!"));
+    console.warn(chalk.yellow("Warning: command named '"+ name + "' was registered more than once.\nIf you intend to override a command, you should explicitly remove the first command with command.remove()."));
   }
 
   this.emit('command_registered', {command: cmd, name: name});

--- a/lib/vorpal.js
+++ b/lib/vorpal.js
@@ -261,6 +261,8 @@ vorpal.command = function (name, desc, opts) {
   }
   if (!exists) {
     this.commands.push(cmd);
+  } else {
+    console.warn(chalk.red("Warning! Command with name '"+ name + "' was registered more than once!"));
   }
 
   this.emit('command_registered', {command: cmd, name: name});


### PR DESCRIPTION
Nice project you have there, thought I'd do my best to pitch in a bit.

This PR causes a nice obvious red warning message to be printed if an user attempts to register an action with the same name twice, in regards to issue #12 . Throwing an error would be another option, but I think printing a warning is a bit more user-friendly. Up to you, though :)