### PR TITLE
Auto-complete when typing piped commands #22

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -258,21 +258,35 @@ session.history = function (str) {
 
 session.getAutocomplete = function (str, cb) {
   cb = cb || function () {};
-  var typed = String(str);
+
+  // Entire command string
+  var trimmed = new String(str).trim();
+
+  // Set "trimmed" to command string after pipe
+  // Set "pre" to command string, pipe, and a space
+  var pre = '';
+  var lastPipeIndex = trimmed.lastIndexOf('|');
+  if (lastPipeIndex !== -1) {
+    pre = trimmed.substr(0, lastPipeIndex + 1) + ' ';
+    trimmed = trimmed.substr(lastPipeIndex + 1).trim();
+  }
+
+  // Complete command
   var names = _.pluck(this.parent.commands, '_name');
-  var result = this._autocomplete(str, names);
-  if (result && String(str).trim().length < String(result).trim().length) {
-    cb(undefined, result);
+  var result = this._autocomplete(trimmed, names);
+  if (result && trimmed.length < String(result).trim().length) {
+    cb(undefined, pre + result);
     return;
   }
 
+  // Find custom autocompletion
   var match;
   var extra;
 
   names.forEach(function (name) {
-    if (typed.substr(0, name.length) === name && String(name).trim() !== '') {
+    if (trimmed.substr(0, name.length) === name && String(name).trim() !== '') {
       match = name;
-      extra = typed.substr(name.length, typed.length);
+      extra = trimmed.substr(name.length).trim();
     }
   });
 
@@ -283,13 +297,23 @@ session.getAutocomplete = function (str, cb) {
   if (!command) {
     command = _.findWhere(this.parent.commands, {_catch: true});
     if (command) {
-      extra = str;
+      extra = trimmed;
     }
   }
 
   if (command && _.isFunction(command._autocompletion)) {
     this._tabCtr++;
-    command._autocompletion.call(this, extra, this._tabCtr, cb);
+    command._autocompletion.call(this, extra, this._tabCtr, function(err, autocomplete) {
+      if (err) {
+        return cb(err);
+      }
+
+      if (_.isArray(autocomplete)) {
+        return cb(void 0, autocomplete);
+      } else {
+        return cb(void 0, pre + autocomplete);
+      }
+    });
   } else {
     cb(undefined, undefined);
   }


### PR DESCRIPTION
I've tested to ensure no behavior is broken. Specifically, the calculator example app works with tabbed autocompletion, and the "tab to double number" works even in pipes.

I'm not sure how to write tests for the tabbed autocompletion since none exist for the existing functionality already.

All of the passing tests continue to pass.