### PR TITLE
Persisting command history

### DIFF
--- a/lib/history.js
+++ b/lib/history.js
@@ -2,7 +2,7 @@
 
 var _ = require('lodash');
 var LocalStorage = require('node-localstorage').LocalStorage;
-var localStorage = new LocalStorage('./cmd_history');
+var localStorage = new LocalStorage('./.cmd_history');
 
 // Number of command histories kept in persistent storage
 var HISTORY_SIZE = 50;

--- a/lib/history.js
+++ b/lib/history.js
@@ -1,0 +1,111 @@
+'use strict';
+
+var _ = require('lodash');
+var LocalStorage = require('node-localstorage').LocalStorage;
+var localStorage = new LocalStorage('./cmd_history');
+
+// Number of command histories kept in persistent storage
+var HISTORY_SIZE = 50;
+
+var History = function () {
+  // Prompt Command History
+  // Histctr moves based on number of times 'up' (+= ctr)
+  //  or 'down' (-= ctr) was pressed in traversing
+  // command history.
+  this._hist = [];
+  this._histCtr = 0;
+
+  // When in a 'mode', we reset the
+  // history and store it in a cache until
+  // exiting the 'mode', at which point we
+  // resume the original history.
+  this._histCache = [];
+  this._histCtrCache = 0;
+};
+
+/**
+ * Initialize the history with local storage data
+ * Called when session is initialized
+ */
+History.prototype.init = function () {
+  // Load history from local storage
+  // Read cmd_history_cache first in case we exited from a mode last time.
+  var persistedHistory = JSON.parse(localStorage.getItem('cmd_history'));
+  if (_.isArray(persistedHistory)) {
+    Array.prototype.push.apply(this._hist, persistedHistory);
+  }
+};
+
+/**
+ * Get previous history. Called when up is pressed.
+ * @return {String}
+ */
+History.prototype.getPreviousHistory = function () {
+  this._histCtr++;
+  this._histCtr = (this._histCtr > this._hist.length) ? this._hist.length : this._histCtr;
+  return this._hist[this._hist.length - (this._histCtr)];
+};
+
+/**
+ * Get next history. Called when down is pressed.
+ * @return {String}
+ */
+History.prototype.getNextHistory = function () {
+  this._histCtr--;
+
+  // Return empty prompt if the we dont have any history to show
+  if (this._histCtr < 1) {
+    this._histCtr = 0;
+    return '';
+  }
+
+  return this._hist[this._hist.length - (this._histCtr)];
+};
+
+/**
+ * A new command was submitted. Called when enter is pressed and the prompt is not empty.
+ * @param cmd
+ */
+History.prototype.newCommand = function (cmd) {
+  this._hist.push(cmd);
+  this._histCtr = 0;
+
+  // Only persist history when not in mode
+  if (!this._inMode) {
+    var persistedHistory = this._hist;
+    var historyLen = this._hist.length;
+    if (historyLen > HISTORY_SIZE) {
+      persistedHistory = this._hist.slice(historyLen - HISTORY_SIZE - 1, historyLen - 1);
+    }
+
+    // Add to local storage
+    localStorage.setItem('cmd_history', JSON.stringify(persistedHistory));
+  }
+};
+
+/**
+ * Called when entering a mode
+ */
+History.prototype.enterMode = function () {
+  // Reassign the command history to a
+  // cache, replacing it with a blank
+  // history for the mode.
+  this._histCache = _.clone(this._hist);
+  this._histCtrCache = parseFloat(this._histCtr);
+  this._hist = [];
+  this._histCtr = 0;
+  this._inMode = true;
+};
+
+/**
+ * Called when exiting a mode
+ */
+History.prototype.exitMode = function () {
+  this._hist = this._histCache;
+  this._histCtr = this._histCtrCache;
+  this._histCache = [];
+  this._histCtrCache = 0;
+  this._inMode = false;
+};
+
+module.exports = History;

--- a/lib/history.js
+++ b/lib/history.js
@@ -2,12 +2,14 @@
 
 var _ = require('lodash');
 var LocalStorage = require('node-localstorage').LocalStorage;
-var localStorage = new LocalStorage('./.cmd_history');
 
 // Number of command histories kept in persistent storage
 var HISTORY_SIZE = 50;
+var DEFAULT_STORAGE_PATH = './.cmd_history';
 
 var History = function () {
+  this._storageKey = undefined;
+
   // Prompt Command History
   // Histctr moves based on number of times 'up' (+= ctr)
   //  or 'down' (-= ctr) was pressed in traversing
@@ -25,14 +27,43 @@ var History = function () {
 
 /**
  * Initialize the history with local storage data
- * Called when session is initialized
+ * Called from setId when history id is set
  */
-History.prototype.init = function () {
+History.prototype._init = function () {
+  if (!this._storageKey) {
+    return;
+  }
+
   // Load history from local storage
-  // Read cmd_history_cache first in case we exited from a mode last time.
-  var persistedHistory = JSON.parse(localStorage.getItem('cmd_history'));
+  var persistedHistory = JSON.parse(this._localStorage.getItem(this._storageKey));
   if (_.isArray(persistedHistory)) {
     Array.prototype.push.apply(this._hist, persistedHistory);
+  }
+};
+
+/**
+ * Set id for this history instance.
+ * Calls init internally to initialize
+ * the history with the id.
+ */
+History.prototype.setId = function (id) {
+  // Initialize a localStorage instance with default
+  // path if it is not initialized
+  if (!this._localStorage) {
+    this._localStorage = new LocalStorage(DEFAULT_STORAGE_PATH);
+  }
+  this._storageKey = 'cmd_history' + id;
+  this._init();
+};
+
+/**
+ * Initialize a local storage instance with
+ * the path if not already initialized.
+ * @param path
+ */
+History.prototype.setStoragePath = function (path) {
+  if (!this._localStorage) {
+    this._localStorage = new LocalStorage(path);
   }
 };
 
@@ -71,7 +102,7 @@ History.prototype.newCommand = function (cmd) {
   this._histCtr = 0;
 
   // Only persist history when not in mode
-  if (!this._inMode) {
+  if (this._storageKey && !this._inMode) {
     var persistedHistory = this._hist;
     var historyLen = this._hist.length;
     if (historyLen > HISTORY_SIZE) {
@@ -79,7 +110,7 @@ History.prototype.newCommand = function (cmd) {
     }
 
     // Add to local storage
-    localStorage.setItem('cmd_history', JSON.stringify(persistedHistory));
+    this._localStorage.setItem(this._storageKey, JSON.stringify(persistedHistory));
   }
 };
 
@@ -106,6 +137,16 @@ History.prototype.exitMode = function () {
   this._histCache = [];
   this._histCtrCache = 0;
   this._inMode = false;
+};
+
+/**
+ * Clears the command history
+ * (Currently only used in unit test)
+ */
+History.prototype.clear = function () {
+  if (this._storageKey) {
+    this._localStorage.removeItem(this._storageKey);
+  }
 };
 
 module.exports = History;

--- a/lib/session.js
+++ b/lib/session.js
@@ -37,9 +37,6 @@ function Session(options) {
 
   this.cmdHistory = this.parent.cmdHistory;
 
-  // Initialize command history
-  this.cmdHistory.init();
-
   // Special command mode vorpal is in at the moment,
   // such as REPL. See mode documentation.
   this._mode = undefined;

--- a/lib/session.js
+++ b/lib/session.js
@@ -35,19 +35,10 @@ function Session(options) {
   // pressed on the keyboard.
   this._tabCtr = 0;
 
-  // Prompt Command History
-  // Histctr moves based on number of times 'up' (+= ctr)
-  //  or 'down' (-= ctr) was pressed in traversing
-  // command history.
-  this._hist = [];
-  this._histCtr = 0;
+  this.cmdHistory = this.parent.cmdHistory;
 
-  // When in a 'mode', we reset the
-  // history and store it in a cache until
-  // exiting the 'mode', at which point we
-  // resume the original history.
-  this._histCache = [];
-  this._histCtrCache = 0;
+  // Initialize command history
+  this.cmdHistory.init();
 
   // Special command mode vorpal is in at the moment,
   // such as REPL. See mode documentation.
@@ -236,7 +227,7 @@ session.getKeypressResult = function (key, value, cb) {
 session.history = function (str) {
   var exceptions = [];
   if (str && exceptions.indexOf(String(str).toLowerCase()) === -1) {
-    this._hist.push(str);
+    this.cmdHistory.newCommand(str);
   }
 };
 
@@ -544,14 +535,13 @@ session.completeCommand = function () {
  */
 
 session.getHistory = function (direction) {
+  var history;
   if (direction === 'up') {
-    this._histCtr++;
-    this._histCtr = (this._histCtr > this._hist.length) ? this._hist.length : this._histCtr;
+    history = this.cmdHistory.getPreviousHistory();
   } else if (direction === 'down') {
-    this._histCtr--;
-    this._histCtr = (this._histCtr < 1) ? 1 : this._histCtr;
+    history = this.cmdHistory.getNextHistory();
   }
-  return this._hist[this._hist.length - (this._histCtr)];
+  return history;
 };
 
 /**

--- a/lib/vorpal.js
+++ b/lib/vorpal.js
@@ -16,6 +16,7 @@ var minimist = require('minimist');
 var commons = require('./vorpal-commons');
 var chalk = require('chalk');
 var os = require('os');
+var History = require('./history');
 
 require('native-promise-only');
 
@@ -395,6 +396,11 @@ vorpal._hook = function (fn) {
   this._hooked = true;
   return this;
 };
+
+/**
+ * History module used to get command history
+ */
+vorpal.cmdHistory = new History();
 
 /**
  * Hook the tty prompt to this given instance
@@ -780,13 +786,8 @@ vorpal._exec = function (item) {
       // instead of the `action` function.
       item.fn = init;
       delete item.validate;
-      // Reassign the command history to a
-      // cache, replacing it with a blank
-      // history for the mode.
-      self._histCache = _.clone(self._hist);
-      self._histCtrCache = parseFloat(self._histCtr);
-      self._hist = [];
-      self._histCtr = 0;
+
+      self.cmdHistory.enterMode();
       item.session.modeDelimiter(delimiter);
     } else if (item.session._mode) {
       if (String(modeCommand).trim() === 'exit') {
@@ -844,10 +845,7 @@ vorpal._exec = function (item) {
 vorpal._exitMode = function (options) {
   var ssn = this.getSessionById(options.sessionId);
   ssn._mode = false;
-  this._hist = this._histCache;
-  this._histCtr = this._histCtrCache;
-  this._histCache = [];
-  this._histCtrCache = 0;
+  this.cmdHistory.exitMode();
   ssn.modeDelimiter(false);
 };
 

--- a/lib/vorpal.js
+++ b/lib/vorpal.js
@@ -36,6 +36,9 @@ function Vorpal() {
   // Exposed through vorpal.version(str);
   this._version = '';
 
+  // Command line history instance
+  this.cmdHistory = new this.CmdHistoryExtension();
+
   // Registered `vorpal.command` commands and
   // their options.
   this.commands = [];
@@ -400,7 +403,30 @@ vorpal._hook = function (fn) {
 /**
  * History module used to get command history
  */
-vorpal.cmdHistory = new History();
+vorpal.CmdHistoryExtension = History;
+
+/**
+ * Set id for command line history
+ * @param id
+ * @return {Vorpal}
+ * @api public
+ */
+vorpal.history = function (id) {
+  this.cmdHistory.setId(id);
+  return this;
+};
+
+/**
+ * Set the path to where command line history is persisted.
+ * Must be called before vorpal.history
+ * @param path
+ * @return {Vorpal}
+ * @api public
+ */
+vorpal.historyStoragePath = function (path) {
+  this.cmdHistory.setStoragePath(path);
+  return this;
+};
 
 /**
  * Hook the tty prompt to this given instance

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "log-update": "^1.0.2",
     "minimist": "^1.2.0",
     "native-promise-only": "^0.8.0-a",
+    "node-localstorage": "^0.6.0",
     "strip-ansi": "^3.0.0"
   },
   "engines": {

--- a/test/integration.js
+++ b/test/integration.js
@@ -3,6 +3,7 @@
 var Vorpal = require('../');
 var commands = require('./util/server');
 var BlueBirdPromise = require('bluebird');
+var fs = require('fs');
 
 require('assert');
 require('should');
@@ -426,32 +427,57 @@ describe('integration tests:', function () {
     });
 
     describe('history', function () {
+      var vorpalHistory;
+      var UNIT_TEST_STORAGE_PATH = './.unit_test_cmd_history';
       before(function () {
-        vorpal.exec('command1');
-        vorpal.exec('command2');
+        vorpalHistory = new Vorpal();
+        vorpalHistory.historyStoragePath(UNIT_TEST_STORAGE_PATH);
+        vorpalHistory.history('unit_test');
+        vorpalHistory.exec('command1');
+        vorpalHistory.exec('command2');
+      });
+
+      after(function (done) {
+        // Clean up history
+        vorpalHistory.cmdHistory.clear();
+
+        // Clean up directory created to store history
+        fs.rmdir(UNIT_TEST_STORAGE_PATH, function () {
+          done();
+        });
       });
 
       it('should be able to get history', function () {
-        vorpal.session.getHistory('up').should.equal('command2');
-        vorpal.session.getHistory('up').should.equal('command1');
-        vorpal.session.getHistory('down').should.equal('command2');
-        vorpal.session.getHistory('down').should.equal('');
+        vorpalHistory.session.getHistory('up').should.equal('command2');
+        vorpalHistory.session.getHistory('up').should.equal('command1');
+        vorpalHistory.session.getHistory('down').should.equal('command2');
+        vorpalHistory.session.getHistory('down').should.equal('');
       });
 
       it('should keep separate history for mode', function () {
-        vorpal.cmdHistory.enterMode();
-        vorpal.exec('command3');
+        vorpalHistory.cmdHistory.enterMode();
+        vorpalHistory.exec('command3');
 
-        vorpal.session.getHistory('up').should.equal('command3');
-        vorpal.session.getHistory('up').should.equal('command3');
-        vorpal.session.getHistory('down').should.equal('');
+        vorpalHistory.session.getHistory('up').should.equal('command3');
+        vorpalHistory.session.getHistory('up').should.equal('command3');
+        vorpalHistory.session.getHistory('down').should.equal('');
 
-        vorpal.cmdHistory.exitMode();
+        vorpalHistory.cmdHistory.exitMode();
 
-        vorpal.session.getHistory('up').should.equal('command2');
-        vorpal.session.getHistory('up').should.equal('command1');
-        vorpal.session.getHistory('down').should.equal('command2');
-        vorpal.session.getHistory('down').should.equal('');
+        vorpalHistory.session.getHistory('up').should.equal('command2');
+        vorpalHistory.session.getHistory('up').should.equal('command1');
+        vorpalHistory.session.getHistory('down').should.equal('command2');
+        vorpalHistory.session.getHistory('down').should.equal('');
+      });
+
+      it('should persist history', function () {
+        var vorpalHistory2 = new Vorpal();
+        vorpalHistory2.historyStoragePath(UNIT_TEST_STORAGE_PATH);
+        vorpalHistory2.history('unit_test');
+        vorpalHistory2.session.getHistory('up').should.equal('command2');
+        vorpalHistory2.session.getHistory('up').should.equal('command1');
+        vorpalHistory2.session.getHistory('down').should.equal('command2');
+        vorpalHistory2.session.getHistory('down').should.equal('');
       });
     });
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -425,6 +425,36 @@ describe('integration tests:', function () {
       });
     });
 
+    describe('history', function () {
+      before(function () {
+        vorpal.exec('command1');
+        vorpal.exec('command2');
+      });
+
+      it('should be able to get history', function () {
+        vorpal.session.getHistory('up').should.equal('command2');
+        vorpal.session.getHistory('up').should.equal('command1');
+        vorpal.session.getHistory('down').should.equal('command2');
+        vorpal.session.getHistory('down').should.equal('');
+      });
+
+      it('should keep separate history for mode', function () {
+        vorpal.cmdHistory.enterMode();
+        vorpal.exec('command3');
+
+        vorpal.session.getHistory('up').should.equal('command3');
+        vorpal.session.getHistory('up').should.equal('command3');
+        vorpal.session.getHistory('down').should.equal('');
+
+        vorpal.cmdHistory.exitMode();
+
+        vorpal.session.getHistory('up').should.equal('command2');
+        vorpal.session.getHistory('up').should.equal('command1');
+        vorpal.session.getHistory('down').should.equal('command2');
+        vorpal.session.getHistory('down').should.equal('');
+      });
+    });
+
     describe('cancel', function () {
       var longRunningCommand;
       before(function () {


### PR DESCRIPTION
#36 Added persistent command history
Implementation can be overridden by overriding vorpal.cmdHistory as long as the interface is maintained