### PR TITLE
Autocompletion now completes to the last matching character

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -339,7 +339,7 @@ session._autocomplete = function (str, arr) {
       return undefined;
     }
     var furthest = strX;
-    for (var k = strX.length; k < matches[0].length; ++k) {
+    for (var k = strX.length; k <= matches[0].length; ++k) {
       var curr = String(matches[0].slice(0, k)).toLowerCase();
       var same = 0;
       for (var j = 0; j < matches.length; ++j) {


### PR DESCRIPTION
 if there are multiple matching commands, the last matching character is not displayed when hitting [tab]. In the below example, typing 'comm[tab]' autocompletes to 'comman' instead of 'command'.

```
var vorpal = require('vorpal')();
vorpal.command('command')
  .action(function (args, cb) {
    this.log('hello');
    cb();
  });

vorpal.command('command2')
  .action(function(args, cb) {
        this.log('hello world');
        cb();
  });

vorpal
  .show();