### PR TITLE
Adds disallowUnknownOptions() method to command

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -36,7 +36,6 @@ function Command(name, parent) {
   }
   this.commands = [];
   this.options = [];
-  this._allowUnknownOptions = true;
   this._args = [];
   this._aliases = [];
   this._name = name;
@@ -385,19 +384,6 @@ command.helpInformation = function () {
 
 command.hidden = function () {
   this._hidden = true;
-  return this;
-};
-
-/**
- * Shows the help for this command if the user
- * supplies an option that is not the options list
- *
- * @return {Command}
- * @api public
- */
-
-command.disallowUnknownOptions = function () {
-  this._allowUnknownOptions = false;
   return this;
 };
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -36,7 +36,7 @@ function Command(name, parent) {
   }
   this.commands = [];
   this.options = [];
-  this._allowUnknownOption = false;
+  this._allowUnknownOptions = true;
   this._args = [];
   this._aliases = [];
   this._name = name;
@@ -385,6 +385,19 @@ command.helpInformation = function () {
 
 command.hidden = function () {
   this._hidden = true;
+  return this;
+};
+
+/**
+ * Shows the help for this command if the user
+ * supplies an option that is not the options list
+ *
+ * @return {Command}
+ * @api public
+ */
+
+command.disallowUnknownOptions = function () {
+  this._allowUnknownOptions = false;
   return this;
 };
 

--- a/lib/option.js
+++ b/lib/option.js
@@ -1,6 +1,11 @@
 'use strict';
 
 /**
+ * Module dependencies
+ */
+var _ = require('lodash');
+
+/**
  * Expose `Option`.
  */
 
@@ -22,9 +27,9 @@ function Option(flags, description) {
   this.bool = !~flags.indexOf('-no-');
   flags = flags.split(/[ ,|]+/);
   if (flags.length > 1 && !/^[[<]/.test(flags[1])) {
-    this.short = flags.shift();
+    assignFlag.call(this, flags.shift());
   }
-  this.long = flags.shift();
+  assignFlag.call(this, flags.shift());
   this.description = description || '';
   return this;
 }
@@ -37,9 +42,13 @@ function Option(flags, description) {
  */
 
 Option.prototype.name = function () {
-  return this.long
-    .replace('--', '')
-    .replace('no-', '');
+  if (this.long !== undefined) {
+    return this.long
+      .replace('--', '')
+      .replace('no-', '');
+  }
+  return this.short
+    .replace('-', '');
 };
 
 /**
@@ -53,3 +62,11 @@ Option.prototype.name = function () {
 Option.prototype.is = function (arg) {
   return (arg === this.short || arg === this.long);
 };
+
+function assignFlag(flag) {
+  if (_.startsWith(flag, '--')) {
+    this.long = flag;
+  } else {
+    this.short = flag;
+  }
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -203,6 +203,29 @@ var util = {
       }
     }
 
+    // Looks for supplied options that don't
+    // exist in the options list and throws help
+    if (cmd._allowUnknownOptions === false) {
+      var passedOpts = _.chain(parsedArgs)
+        .keys()
+        .pull('_')
+        .value();
+      for (var n = 0; n < passedOpts.length; ++n) {
+        var opt = passedOpts[n];
+        var optionFound = _.find(cmd.options, function (expected) {
+          if ('--' + opt === expected.long ||
+              '--no-' + opt === expected.long ||
+              '-' + opt === expected.short) {
+            return true;
+          }
+          return false;
+        });
+        if (optionFound === undefined) {
+          return '\n  Unknown option: ' + opt + '. Showing Help:';
+        }
+      }
+    }
+
     // If args were passed into the programmatic
     // `vorpal.exec(cmd, args, callback)`, merge
     // them here.

--- a/lib/util.js
+++ b/lib/util.js
@@ -205,24 +205,23 @@ var util = {
 
     // Looks for supplied options that don't
     // exist in the options list and throws help
-    if (cmd._allowUnknownOptions === false) {
-      var passedOpts = _.chain(parsedArgs)
-        .keys()
-        .pull('_')
-        .value();
-      for (var n = 0; n < passedOpts.length; ++n) {
-        var opt = passedOpts[n];
-        var optionFound = _.find(cmd.options, function (expected) {
-          if ('--' + opt === expected.long ||
-              '--no-' + opt === expected.long ||
-              '-' + opt === expected.short) {
-            return true;
-          }
-          return false;
-        });
-        if (optionFound === undefined) {
-          return '\n  Unknown option: ' + opt + '. Showing Help:';
+    var passedOpts = _.chain(parsedArgs)
+      .keys()
+      .pull('_')
+      .pull('help')
+      .value();
+    for (var n = 0; n < passedOpts.length; ++n) {
+      var opt = passedOpts[n];
+      var optionFound = _.find(cmd.options, function (expected) {
+        if ('--' + opt === expected.long ||
+            '--no-' + opt === expected.long ||
+            '-' + opt === expected.short) {
+          return true;
         }
+        return false;
+      });
+      if (optionFound === undefined) {
+        return '\n  Invalid option: \'' + opt + '\'. Showing Help:';
       }
     }
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -378,6 +378,13 @@ describe('integration tests:', function () {
         });
       });
 
+      it('should show help when passed an unknown option and disallowUnknownOptions is set', function (done) {
+        exec('unknown-option --unknown-opt', done, function () {
+          (stdout().indexOf('Unknown option') > -1).should.equal(true);
+          done();
+        });
+      });
+
       it('should should execute a command when passed a required variable', function (done) {
         exec('required foobar', done, function () {
           stdout().should.equal('foobar');

--- a/test/integration.js
+++ b/test/integration.js
@@ -198,8 +198,8 @@ describe('integration tests:', function () {
       });
 
       it('should execute a long command with arguments', function (done) {
-        exec('very complicated deep command abc123 -rad -sleep \'well\' -t -i \'j\' ', done, function () {
-          stdout().should.equal('radtjabc123');
+        exec('very complicated deep command abc123 -rad --sleep \'well\' -t -i \'j\' ', done, function () {
+          stdout().should.equal('radtjwellabc123');
           done();
         });
       });
@@ -378,9 +378,9 @@ describe('integration tests:', function () {
         });
       });
 
-      it('should show help when passed an unknown option and disallowUnknownOptions is set', function (done) {
+      it('should show help when passed an unknown option', function (done) {
         exec('unknown-option --unknown-opt', done, function () {
-          (stdout().indexOf('Unknown option') > -1).should.equal(true);
+          (stdout().indexOf('Invalid option') > -1).should.equal(true);
           done();
         });
       });

--- a/test/util/server.js
+++ b/test/util/server.js
@@ -158,6 +158,15 @@ module.exports = function (vorpal) {
     });
 
   vorpal
+    .command('unknown-option')
+    .description('Must return an arg.')
+    .disallowUnknownOptions()
+    .action(function (args, cb) {
+      this.log('should never see this');
+      cb(undefined, args);
+    });
+
+  vorpal
     .command('fail me <arg>')
     .description('Must return an arg.')
     .action(function (args) {

--- a/test/util/server.js
+++ b/test/util/server.js
@@ -159,8 +159,7 @@ module.exports = function (vorpal) {
 
   vorpal
     .command('unknown-option')
-    .description('Must return an arg.')
-    .disallowUnknownOptions()
+    .description('shows help if we pass any unknown option.')
     .action(function (args, cb) {
       this.log('should never see this');
       cb(undefined, args);


### PR DESCRIPTION
Will display help if user enters an option that is not in the options array.  Current default behavior is to silently ignore unknown options.  If you have a command
```
.command('cmd')
.option('--a')
.disallowUnknownOptions()
.action(...)
```
Now if the user enters `cmd --a --b`, the output is `Unknown option: b. Showing Help: ...`.
The action is not invoked
