### PR TITLE
Replaced _.pluck with _.map because of Lodash 4.0.0

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -263,8 +263,8 @@ session.getAutocomplete = function (str, cb) {
   }
 
   // Complete command
-  var names = _.pluck(this.parent.commands, '_name');
-  names = names.concat.apply(names, _.pluck(this.parent.commands, '_aliases'));
+  var names = _.map(this.parent.commands, '_name');
+  names = names.concat.apply(names, _.map(this.parent.commands, '_aliases'));
   var result = this._autocomplete(trimmed, names);
   if (result && trimmed.length < String(result).trim().length) {
     cb(undefined, pre + result + remainder);

--- a/lib/util.js
+++ b/lib/util.js
@@ -122,7 +122,7 @@ var util = {
       // there is a command `do things well`. If we match partially,
       // we still want to show the help menu for that command group.
       if (match) {
-        var allCommands = _.pluck(cmds, '_name');
+        var allCommands = _.map(cmds, '_name');
         var wordMatch = false;
         for (var n = 0; n < allCommands.length; ++n) {
           var parts2 = String(allCommands[n]).split(' ');

--- a/lib/vorpal.js
+++ b/lib/vorpal.js
@@ -1090,7 +1090,7 @@ vorpal.getSessionById = function (id) {
   if (!ssn) {
     var sessions = {
       local: this.session.id,
-      server: _.pluck(this.server.sessions, 'id')
+      server: _.map(this.server.sessions, 'id')
     };
     throw new Error('No session found for id ' + id + ' in vorpal.getSessionById. Sessions: ' + JSON.stringify(sessions));
   }


### PR DESCRIPTION
Lodash 4.0.0 deprecated _.pluck in favor of _.map which has the same behavior.

From [this](https://github.com/lodash/lodash/wiki/Changelog#v400)
>Removed _.pluck in favor of _.map with iteratee shorthand:
>`var objects = [{ 'a': 1 }, { 'a': 2 }];`
>`// in 3.10.1`
>` _.pluck(objects, 'a'); // → [1, 2]`
>` _.map(objects, 'a'); // → [1, 2]`
>` // in 4.0.0`
>` _.map(objects, 'a'); // → [1, 2]`
