### PR TITLE
Fix command autocomplete behavior

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -363,7 +363,7 @@ session._autocomplete = function (str, arr) {
     var longestMatchLength = shortestMatchLength;
     var firstMatch = matches[0];
     for (var pos = str.length; pos < shortestMatchLength; pos++) {
-      var allMatchesHaveSameChar = _.all(matches, function (m) {
+      var allMatchesHaveSameChar = _.every(matches, function (m) {
         return m[pos] === firstMatch[pos];
       });
       if (!allMatchesHaveSameChar) {

--- a/lib/session.js
+++ b/lib/session.js
@@ -265,7 +265,14 @@ session.getAutocomplete = function (str, cb) {
   // Complete command
   var names = _.map(this.parent.commands, '_name');
   names = names.concat.apply(names, _.map(this.parent.commands, '_aliases'));
-  var result = this._autocomplete(trimmed, names);
+  // we use 'str' here because if the user enters my-cmd[space][tab], that should not be autocompleted to
+  // my-cmd2 for example
+  var result = this._autocomplete(str, names);
+  if (_.isArray(result)) {
+    cb(undefined, result);
+    return;
+  }
+
   if (result && trimmed.length < String(result).trim().length) {
     cb(undefined, pre + result + remainder);
     return;
@@ -313,7 +320,13 @@ session.getAutocomplete = function (str, cb) {
 
 /**
  * Independent / stateless auto-complete function.
- * Parses an array of strings for the best match.
+ * Parses an array of strings and returns:
+ * if no matches: undefined
+ * if 1 match: the whole match
+ * if multiple matches and they have common charaters, returns the furthest portion of
+ * commonality
+ * if multiple matches and there is no further commonality, the array of matches
+ * see test/autocomplete.js for examples
  *
  * @param {String} str
  * @param {Array} arr
@@ -338,28 +351,35 @@ session._autocomplete = function (str, arr) {
     } else if (matches.length === 0) {
       return undefined;
     }
-    var furthest = strX;
-    for (var k = strX.length; k <= matches[0].length; ++k) {
-      var curr = String(matches[0].slice(0, k)).toLowerCase();
-      var same = 0;
-      for (var j = 0; j < matches.length; ++j) {
-        var sliced = String(matches[j].slice(0, curr.length)).toLowerCase();
-        if (sliced === curr) {
-          same++;
-        }
-      }
-      if (same === matches.length) {
-        furthest = curr;
-        continue;
-      } else {
+
+    var shortestMatchLength = _.reduce(matches, function (acc, value) {
+      return value.length < acc ? value.length : acc;
+    }, 99999);
+
+    // starting at position str.length, if all matches share the same char in this
+    // position, increment position. When we get to a position where not all matches
+    // match, this is the longest string we can autocomplete
+    var longestMatchLength = shortestMatchLength;
+    var firstMatch = matches[0];
+    for (var pos = str.length; pos < shortestMatchLength; pos++) {
+      var allMatchesHaveSameChar = _.all(matches, function (m) {
+        return m[pos] === firstMatch[pos];
+      });
+      if (!allMatchesHaveSameChar) {
+        longestMatchLength = pos;
         break;
       }
     }
-    if (furthest !== strX) {
-      return furthest;
+
+    // couldn't resolve any further, return all matches
+    if (longestMatchLength === str.length) {
+      return matches;
     }
-    return undefined;
+
+    // return the longest matching portion
+    return matches[0].substr(0, longestMatchLength);
   };
+
   return go();
 };
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -259,7 +259,7 @@ var ui = {
     prompt.screen.render(message, {cursor: cursor});
 
     var key = (e.key || {}).name;
-    var value = (prompt) ? String(prompt.rl.line).trim() : undefined;
+    var value = (prompt) ? String(prompt.rl.line) : undefined;
     this.emit('vorpal_ui_keypress', {key: key, value: value, e: e});
   },
 

--- a/test/autocomplete.js
+++ b/test/autocomplete.js
@@ -1,0 +1,110 @@
+var Vorpal = require('../');
+var assert = require('assert');
+var _ = require('lodash');
+var vorpal = new Vorpal();
+
+describe('session._autocomplete', function () {
+  it('should return longest possible match', function () {
+    var result = vorpal.session._autocomplete('c', ['cmd', 'cme', 'def']);
+    assert.equal(result, 'cm');
+  });
+
+  it('should return list of matches when there are no more common characters', function () {
+    var result = vorpal.session._autocomplete('c', ['cmd', 'ced']);
+    assert.equal(result.length, 2);
+    assert.equal(result[0], 'ced');
+    assert.equal(result[1], 'cmd');
+  });
+
+  it('should return list of matches even if we have a complete match', function () {
+    var result = vorpal.session._autocomplete('cmd', ['cmd', 'cmd2']);
+    assert.equal(result.length, 2);
+    assert.equal(result[0], 'cmd');
+    assert.equal(result[1], 'cmd2');
+  });
+
+  it('should return undefined if no match', function () {
+    var result = vorpal.session._autocomplete('cmd', ['def', 'xyz']);
+    assert.equal(result, undefined);
+  });
+
+  it('should return the match if only a single possible match exists', function () {
+    var result = vorpal.session._autocomplete('d', ['def', 'xyz']);
+    assert.equal(result, 'def ');
+  });
+});
+
+describe('session.getAutocomplete', function () {
+  beforeEach(function () {
+    vorpal.commands.length = 0;
+  });
+
+  after(function () {
+    vorpal.ui._activePrompt = undefined;
+  });
+
+  it('should return undefined if name matches command with no autocomplete function', function (done) {
+    _.set(vorpal.ui, '_activePrompt.screen.rl.cursor', 3);
+    vorpal.command('cmd');
+    vorpal.session.getAutocomplete('cmd', function (err, res) {
+      assert.equal(err, undefined);
+      assert.equal(res, undefined);
+      done();
+    });
+  });
+
+  it('should return all matching commands if there are > 1 matches', function (done) {
+    _.set(vorpal.ui, '_activePrompt.screen.rl.cursor', 3);
+    vorpal.command('cmd')
+    .autocompletion(function (text, iteration, cb) {
+      cb(undefined, 'helloworld');
+    });
+    vorpal.command('cmd2');
+    vorpal.session.getAutocomplete('cmd', function (err, res) {
+      assert.equal(err, undefined);
+      assert(_.isArray(res));
+      assert.equal(res.length, 2);
+      done();
+    });
+  });
+
+  it('should invoke custom autocompletion if there is only 1 command match', function (done) {
+    _.set(vorpal.ui, '_activePrompt.screen.rl.cursor', 3);
+    vorpal.command('cmd')
+    .autocompletion(function (text, iteration, cb) {
+      cb(undefined, 'helloworld');
+    });
+    vorpal.session.getAutocomplete('cmd', function (err, res) {
+      assert.equal(err, undefined);
+      assert.equal(res, 'helloworld');
+      done();
+    });
+  });
+
+  it('should invoke custom autocompletion if there is a space after the command name, even ' +
+    'if there are other possible command matches', function (done) {
+    _.set(vorpal.ui, '_activePrompt.screen.rl.cursor', 3);
+    vorpal.command('cmd')
+    .autocompletion(function (text, iteration, cb) {
+      return cb(undefined, 'helloworld');
+    });
+    vorpal.command('cmd2');
+    vorpal.session.getAutocomplete('cmd ', function (err, res) {
+      assert.equal(err, undefined);
+      assert.equal(res, 'helloworld');
+      done();
+    });
+  });
+
+  it('should do *something* with piped commands', function (done) {
+    _.set(vorpal.ui, '_activePrompt.screen.rl.cursor', 10);
+    vorpal.command('cmd')
+    .autocompletion(function (text, iteration, cb) {
+      return cb(undefined, 'helloworld');
+    });
+    vorpal.session.getAutocomplete('cmd | less', function (err) {
+      assert.equal(err, undefined);
+      done();
+    });
+  });
+});

--- a/test/integration.js
+++ b/test/integration.js
@@ -9,6 +9,7 @@ require('assert');
 require('should');
 
 var vorpal = new Vorpal();
+
 var _all = '';
 var _stdout = '';
 var _excess = '';


### PR DESCRIPTION
Changes command autocomplete behavior in the following cases:
  - if there are > 1 possible matches, print out the matches underneath the current command
  - if we have 'cmd', 'cmd2' commands, only invoke custom autocompletion once the user has entered 'cmd'[space]. Previously we would invoke custom autocompletion on 'cmd' where the user might have wanted to use command autocompletion to list 'cmd2'

Simplified longest match algorithm, added test cases (test/autocomplete.js)