### PR TITLE
fix(prompt): Fixes the prompt not displaying the default value.

### DIFF
--- a/dist/ui.js
+++ b/dist/ui.js
@@ -54,6 +54,9 @@ var UI = function (_EventEmitter) {
     // Handle for inquirer's prompt.
     _this.inquirer = inquirer;
 
+    // prompt history from inquirer
+    _this.inquirerStdout = [];
+
     // Whether a prompt is currently in cancel mode.
     _this._cancelled = false;
 
@@ -208,6 +211,7 @@ var UI = function (_EventEmitter) {
       this._midPrompt = true;
       try {
         prompt = inquirer.prompt(options, function (result) {
+          _this2.inquirerStdout = [];
           _this2._midPrompt = false;
           if (_this2._cancel === true) {
             _this2._cancel = false;
@@ -260,7 +264,12 @@ var UI = function (_EventEmitter) {
       };
       inquirer.prompt.prompts.input.prototype.getQuestion = function () {
         self._activePrompt = this;
-        return this.opt.message;
+        var message = this.opt.message;
+        if (this.opt.default !== null && this.status !== 'answered') {
+          message += chalk.dim('(' + this.opt.default + ') ');
+        }
+        self.inquirerStdout.push(message);
+        return message;
       };
     }
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -42,6 +42,9 @@ class UI extends EventEmitter {
     // Handle for inquirer's prompt.
     this.inquirer = inquirer;
 
+    // prompt history from inquirer
+    this.inquirerStdout = [];
+
     // Whether a prompt is currently in cancel mode.
     this._cancelled = false;
 
@@ -185,6 +188,7 @@ class UI extends EventEmitter {
     this._midPrompt = true;
     try {
       prompt = inquirer.prompt(options, (result) => {
+        this.inquirerStdout = [];
         this._midPrompt = false;
         if (this._cancel === true) {
           this._cancel = false;
@@ -234,7 +238,12 @@ class UI extends EventEmitter {
     };
     inquirer.prompt.prompts.input.prototype.getQuestion = function () {
       self._activePrompt = this;
-      return this.opt.message;
+      let message = this.opt.message;
+      if (this.opt.default !== null && this.status !== 'answered') {
+        message += chalk.dim('(' + this.opt.default + ') ');
+      }
+      self.inquirerStdout.push(message);
+      return message;
     };
   }
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -235,6 +235,42 @@ describe('integration tests:', function () {
       });
     });
 
+    describe('inquirer prompt', function(){
+      var parent = Vorpal();
+
+      beforeEach(function(){
+        // attach a parent so the prompt will run
+         vorpal.ui.attach(parent);
+      });
+
+      afterEach(function(){
+        vorpal.ui.detach(parent);
+      });
+
+      it('should show the default value', function(done){
+        var execPromise = vorpal.exec('prompt default myawesomeproject');
+
+        vorpal.ui.inquirerStdout.join('\n').should.containEql('(myawesomeproject)');
+
+        execPromise
+          .then(function (s) {
+            s.project.should.equal('myawesomeproject');
+            // stdout should have cleared once the prompt is finished
+            vorpal.ui.inquirerStdout.join('\n').should.not.containEql('(myawesomeproject)');
+            done();
+          })
+          .catch(function (err) {
+            console.log(stdout());
+            console.log('b', err.stack);
+            true.should.not.be.true;
+            done(err);
+          });
+
+        // submit the default
+        vorpal.ui.submit();
+      });
+    });
+
     describe('synchronous execution', function () {
       it('should execute a sync command', function () {
         var result = vorpal.execSync('sync');

--- a/test/util/server.js
+++ b/test/util/server.js
@@ -31,6 +31,20 @@ module.exports = function (vorpal) {
       cb();
     });
 
+  vorpal.command('prompt default <defaultValue>', 'action prompt')
+    .action(function(args, cb) {
+
+      return this.prompt([
+        {
+          type: 'input',
+          name: 'project',
+          message: 'Project: ',
+          default: args.defaultValue
+        }
+      ]);
+
+    });
+
   vorpal.command('parse me <words>', 'Takes input and adds a reverse pipe to it.')
     .parse(function (str) {
       return str + ' | reverse';


### PR DESCRIPTION
This fixes the inquirer default values not being displayed.

Note that I could not use `inquirer.prompt.prompts.input.prototype.getQuestion.call()` directly as inquirer prefixes the delimiter with `?`, which is not desired for vorpal as it controls it's own delimiter.

Instead the functionality defined in https://github.com/SBoudrias/Inquirer.js/blob/20c3c5d8a91df5022a9a31aa739f3dd6c92a22e7/lib/prompts/base.js#L122 is replicated

Fixes #125 
