### PR TITLE
Fixed missing attach for parse function.

### DIFF
--- a/dist/option.js
+++ b/dist/option.js
@@ -22,7 +22,7 @@ var Option = function () {
     this.flags = flags;
     this.required = ~flags.indexOf('<');
     this.optional = ~flags.indexOf('[');
-    this.bool = ! ~flags.indexOf('-no-');
+    this.bool = !~flags.indexOf('-no-');
     this.autocomplete = autocomplete;
     flags = flags.split(/[ ,|]+/);
     if (flags.length > 1 && !/^[[<]/.test(flags[1])) {

--- a/dist/vorpal.js
+++ b/dist/vorpal.js
@@ -163,6 +163,7 @@ Vorpal.prototype.parse = function (argv, options) {
           args[i] = '"' + args[i] + '"';
         }
       }
+      ui.attach(result);
       this.exec(args.join(' '), function (err) {
         if (err !== undefined && err !== null) {
           throw new Error(err);

--- a/lib/vorpal.js
+++ b/lib/vorpal.js
@@ -163,6 +163,7 @@ Vorpal.prototype.parse = function (argv, options) {
           args[i] = `"${args[i]}"`;
         }
       }
+      ui.attach(result);
       this.exec(args.join(' '), function (err) {
         if (err !== undefined && err !== null) {
           throw new Error(err);


### PR DESCRIPTION
Fixes https://github.com/dthree/vorpal/issues/164.

It turns out that if I add attach function everything works as expected because now UI module has a parent inside the prompt function.