### PR TITLE
Patches #124 Problems with slashes in autocomplete options

### DIFF
--- a/dist/autocomplete.js
+++ b/dist/autocomplete.js
@@ -101,33 +101,26 @@ var autocomplete = {
       return prefix + matches[0] + space;
     } else if (matches.length === 0) {
       return undefined;
-    }
-    var shortestMatchLength = _.reduce(matches, function (acc, value) {
-      return value.length < acc ? value.length : acc;
-    }, 99999);
-
-    // starting at position str.length, if all matches share the same char in this
-    // position, increment position. When we get to a position where not all matches
-    // match, this is the longest string we can autocomplete
-    var longestMatchLength = shortestMatchLength;
-    var firstMatch = matches[0];
-    for (var pos = str.length; pos < shortestMatchLength; pos++) {
-      var allMatchesHaveSameChar = _.every(matches, function (m) {
-        return m[pos] === firstMatch[pos];
-      });
-      if (!allMatchesHaveSameChar) {
-        longestMatchLength = pos;
-        break;
-      }
-    }
-
-    // couldn't resolve any further, return all matches
-    if (longestMatchLength === str.length) {
+    } else if (strX.length === 0) {
       return matches;
     }
 
-    // return the longest matching portion
-    return matches[0].substr(0, longestMatchLength);
+    var longestMatchLength = matches.reduce(function (previous, current) {
+      for (var i = 0; i < current.length; i++) {
+        if (previous[i] && current[i] !== previous[i]) {
+          return current.substr(0, i);
+        }
+      }
+      return previous;
+    }).length;
+
+    // couldn't resolve any further, return all matches
+    if (longestMatchLength === strX.length) {
+      return matches;
+    }
+
+    // return the longest matching portion along with the prefix
+    return prefix + matches[0].substr(0, longestMatchLength);
   }
 };
 

--- a/lib/autocomplete.js
+++ b/lib/autocomplete.js
@@ -101,33 +101,27 @@ var autocomplete = {
       return prefix + matches[0] + space;
     } else if (matches.length === 0) {
       return undefined;
-    }
-    var shortestMatchLength = _.reduce(matches, function (acc, value) {
-      return value.length < acc ? value.length : acc;
-    }, 99999);
-
-    // starting at position str.length, if all matches share the same char in this
-    // position, increment position. When we get to a position where not all matches
-    // match, this is the longest string we can autocomplete
-    var longestMatchLength = shortestMatchLength;
-    var firstMatch = matches[0];
-    for (var pos = str.length; pos < shortestMatchLength; pos++) {
-      var allMatchesHaveSameChar = _.every(matches, function (m) {
-        return m[pos] === firstMatch[pos];
-      });
-      if (!allMatchesHaveSameChar) {
-        longestMatchLength = pos;
-        break;
-      }
-    }
-
-    // couldn't resolve any further, return all matches
-    if (longestMatchLength === str.length) {
+    } else if (strX.length === 0) {
       return matches;
     }
 
-    // return the longest matching portion
-    return matches[0].substr(0, longestMatchLength);
+    var longestMatchLength = matches
+      .reduce(function (previous, current) {
+        for (var i = 0; i < current.length; i++) {
+          if (previous[i] && current[i] !== previous[i]) {
+            return current.substr(0, i);
+          }
+        }
+        return previous;
+      }).length;
+
+    // couldn't resolve any further, return all matches
+    if (longestMatchLength === strX.length) {
+      return matches;
+    }
+
+    // return the longest matching portion along with the prefix
+    return prefix + matches[0].substr(0, longestMatchLength);
   }
 };
 

--- a/test/autocomplete.js
+++ b/test/autocomplete.js
@@ -32,4 +32,19 @@ describe('session._autocomplete', function () {
     var result = vorpal.session._autocomplete('d', ['def', 'xyz']);
     assert.equal(result, 'def ');
   });
+
+  
+  it('should return the prefix along with the partial match when supplied with a prefix input', function() {
+    var result = vorpal.session._autocomplete('foo/de', ['dally','definitive', 'definitop', 'bob']);
+    assert.equal(result, "foo/definit");
+  });
+
+  it("should return a list of matches when supplied with a prefix but no value post prefix", function() {
+    var result = vorpal.session._autocomplete('foo/', ['dally','definitive', 'definitop', 'bob']);
+    assert.equal(result.length, 4);
+    assert.equal(result[0], "bob");
+    assert.equal(result[1], "dally");
+    assert.equal(result[2], "definitive");
+    assert.equal(result[3], "definitop");
+  });
 });


### PR DESCRIPTION
Fixes autocomplete issue when using slashes.

When a partial match was made after the user entered a command with a slash, the autocomplete function
would ignore the matched prefix.

When a autocomplete was used with a slash the autcomplete would fail when post prefix was an empty string

Tests added
