### PR TITLE
Fix for autocomplete things beginning with / and make it work still for things without /

### DIFF
--- a/dist/autocomplete.js
+++ b/dist/autocomplete.js
@@ -49,7 +49,7 @@ var autocomplete = {
     if (input.match) {
       input = parseMatchSection.call(this, input);
       getMatchData.call(self, input, function (data) {
-        var dataMatch = getMatch(input.context, data);
+        var dataMatch = getMatch(input.context, data, { ignoreSlashes: true });
         if (dataMatch) {
           input.context = dataMatch;
           evaluateTabs(input);

--- a/dist/autocomplete.js
+++ b/dist/autocomplete.js
@@ -49,7 +49,7 @@ var autocomplete = {
     if (input.match) {
       input = parseMatchSection.call(this, input);
       getMatchData.call(self, input, function (data) {
-        var dataMatch = getMatch(input.context, data, { ignoreSlashes: true });
+        var dataMatch = getMatch(input.context, data, { ignoreSlashes: input.context[0] === "/" });
         if (dataMatch) {
           input.context = dataMatch;
           evaluateTabs(input);

--- a/lib/autocomplete.js
+++ b/lib/autocomplete.js
@@ -49,7 +49,7 @@ var autocomplete = {
     if (input.match) {
       input = parseMatchSection.call(this, input);
       getMatchData.call(self, input, function (data) {
-        var dataMatch = getMatch(input.context, data, {ignoreSlashes: true});
+        var dataMatch = getMatch(input.context, data, {ignoreSlashes: input.context[0] === "/"});
         if (dataMatch) {
           input.context = dataMatch;
           evaluateTabs(input);

--- a/lib/autocomplete.js
+++ b/lib/autocomplete.js
@@ -49,7 +49,7 @@ var autocomplete = {
     if (input.match) {
       input = parseMatchSection.call(this, input);
       getMatchData.call(self, input, function (data) {
-        var dataMatch = getMatch(input.context, data);
+        var dataMatch = getMatch(input.context, data, {ignoreSlashes: true});
         if (dataMatch) {
           input.context = dataMatch;
           evaluateTabs(input);


### PR DESCRIPTION
When returning an array of matches to autocomplete which begins with / it ignored the result.
If trying to autocomplete "/t" with result [ "/test/" ] the match was discarded.
Though trying to autocomplete "t" with [ "test/" ] would give the expected result.

This fix makes both cases work.