### PR TITLE
update maintainers

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "inquirer"
   ],
   "author": "dthree",
+  "contributors":[
+	"LongLiveCHIEF <chief@hackerhappyhour.com> (https://github.com/LongLiveCHIEF)" 
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/dthree/vorpal/issues"


### PR DESCRIPTION
author+contributors is used to create a high level "maintainers" file in npm.  I added my info to the `contributors` array.

closes #187
