### PR TITLE
Do not attach ui after parse

### DIFF
--- a/dist/command-instance.js
+++ b/dist/command-instance.js
@@ -22,14 +22,13 @@ var CommandInstance = function () {
    */
 
   function CommandInstance() {
-    var _ref = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
-
-    var command = _ref.command;
-    var commandObject = _ref.commandObject;
-    var args = _ref.args;
-    var commandWrapper = _ref.commandWrapper;
-    var callback = _ref.callback;
-    var downstream = _ref.downstream;
+    var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+        command = _ref.command,
+        commandObject = _ref.commandObject,
+        args = _ref.args,
+        commandWrapper = _ref.commandWrapper,
+        callback = _ref.callback,
+        downstream = _ref.downstream;
 
     _classCallCheck(this, CommandInstance);
 

--- a/dist/command.js
+++ b/dist/command.js
@@ -376,7 +376,7 @@ command.hidden = function () {
  */
 
 command.allowUnknownOptions = function () {
-  var allowUnknownOptions = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
+  var allowUnknownOptions = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
 
   allowUnknownOptions = allowUnknownOptions === "false" ? false : allowUnknownOptions;
 

--- a/dist/command.js
+++ b/dist/command.js
@@ -118,6 +118,18 @@ command.action = function (fn) {
 };
 
 /**
+ * Let's you compose other funtions to extend the command.
+ *
+ * @param {Function} fn
+ * @return {Command}
+ * @api public
+ */
+
+command.use = function (fn) {
+  return fn(this);
+};
+
+/**
  * Defines a function to validate arguments
  * before action is performed. Arguments
  * are valid if no errors are thrown from

--- a/dist/logger.js
+++ b/dist/logger.js
@@ -100,7 +100,7 @@ function Logger(cons) {
           // Ugh. We're chopping a line, so we have to look for unfinished
           // color assignments and throw them on the next line.
           if (matches && matches[matches.length - 1] !== '\\u001b[39m') {
-            trimmed += '\u001b[39m';
+            trimmed += '\x1B[39m';
             var number = String(matches[matches.length - 1]).slice(7, 9);
             color = '\x1B[' + number + 'm';
           }

--- a/dist/option.js
+++ b/dist/option.js
@@ -22,7 +22,7 @@ var Option = function () {
     this.flags = flags;
     this.required = ~flags.indexOf('<');
     this.optional = ~flags.indexOf('[');
-    this.bool = ! ~flags.indexOf('-no-');
+    this.bool = !~flags.indexOf('-no-');
     this.autocomplete = autocomplete;
     flags = flags.split(/[ ,|]+/);
     if (flags.length > 1 && !/^[[<]/.test(flags[1])) {

--- a/dist/ui.js
+++ b/dist/ui.js
@@ -34,7 +34,7 @@ var UI = function (_EventEmitter) {
   function UI() {
     _classCallCheck(this, UI);
 
-    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(UI).call(this));
+    var _this = _possibleConstructorReturn(this, (UI.__proto__ || Object.getPrototypeOf(UI)).call(this));
 
     var self = _this;
 
@@ -193,7 +193,7 @@ var UI = function (_EventEmitter) {
     value: function prompt(options, cb) {
       var _this2 = this;
 
-      var prompt = undefined;
+      var prompt = void 0;
       options = options || {};
       if (!this.parent) {
         return prompt;

--- a/dist/util.js
+++ b/dist/util.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var _ = require('lodash');
 var minimist = require('minimist');
@@ -24,7 +24,7 @@ var util = {
   parseArgs: function parseArgs(str, opts) {
     var reg = /"(.*?)"|'(.*?)'|`(.*?)`|([^\s"]+)/gi;
     var arr = [];
-    var match = undefined;
+    var match = void 0;
     do {
       match = reg.exec(str);
       if (match !== null) {
@@ -49,9 +49,9 @@ var util = {
   parseCommand: function parseCommand(command, commands) {
     var self = this;
     var pipes = [];
-    var match = undefined;
-    var matchArgs = undefined;
-    var matchParts = undefined;
+    var match = void 0;
+    var matchArgs = void 0;
+    var matchParts = void 0;
 
     function parsePipes() {
       // First, split the command by pipes naively.
@@ -146,8 +146,8 @@ var util = {
   matchCommand: function matchCommand(cmd, cmds) {
     var parts = String(cmd).trim().split(' ');
 
-    var match = undefined;
-    var matchArgs = undefined;
+    var match = void 0;
+    var matchArgs = void 0;
     for (var i = 0; i < parts.length; ++i) {
       var subcommand = String(parts.slice(0, parts.length - i).join(' ')).trim();
       match = _.find(cmds, { _name: subcommand }) || match;
@@ -175,8 +175,8 @@ var util = {
       if (match) {
         var allCommands = _.map(cmds, '_name');
         var wordMatch = false;
-        for (var key in allCommands) {
-          var _cmd2 = allCommands[key];
+        for (var _key in allCommands) {
+          var _cmd2 = allCommands[_key];
           var parts2 = String(_cmd2).split(' ');
           var cmdParts = String(match.command).split(' ');
           var matchAll = true;

--- a/dist/vorpal.js
+++ b/dist/vorpal.js
@@ -163,11 +163,11 @@ Vorpal.prototype.parse = function (argv, options) {
           args[i] = '"' + args[i] + '"';
         }
       }
-      ui.attach(result);
       this.exec(args.join(' '), function (err) {
         if (err !== undefined && err !== null) {
           throw new Error(err);
         }
+        process.exit(0);
       });
     }
   }
@@ -540,7 +540,7 @@ vorpal._onKeypress = function (key, value) {
 vorpal.prompt = function () {
   var _this = this;
 
-  var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+  var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   var userCallback = arguments[1];
 
   return new Promise(function (resolve) {
@@ -553,7 +553,7 @@ vorpal.prompt = function () {
       }
     };
 
-    var prompt = undefined;
+    var prompt = void 0;
     var ssn = _this.getSessionById(options.sessionId);
 
     if (!ssn) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -120,6 +120,18 @@ command.action = function (fn) {
 };
 
 /**
+ * Let's you compose other funtions to extend the command.
+ *
+ * @param {Function} fn
+ * @return {Command}
+ * @api public
+ */
+
+command.use = function (fn) {
+  return fn(this);
+};
+
+/**
  * Defines a function to validate arguments
  * before action is performed. Arguments
  * are valid if no errors are thrown from

--- a/lib/vorpal.js
+++ b/lib/vorpal.js
@@ -163,11 +163,11 @@ Vorpal.prototype.parse = function (argv, options) {
           args[i] = `"${args[i]}"`;
         }
       }
-      ui.attach(result);
       this.exec(args.join(' '), function (err) {
         if (err !== undefined && err !== null) {
           throw new Error(err);
         }
+        process.exit(0);
       });
     }
   }


### PR DESCRIPTION
There are a few reasons for this PR.

1. I think its a good idea to be able to use Vorpal simply as a CLI tool without necessarily having to use the interactive shell when using `.parse`

2. I was having some issues where I was starting an express server with a Vorpal command and I would listen to SIGINT and SIGTERM to gracefully shutdown the server, but then I would get this bizarre `Error: read EIO close` error on the next key I typed after exiting with `ctrl-c`. The only way to solve it was with `process.on('SIGINT', () => process.exit(2))`. I don't get this error anymore.

Reference Issue: https://github.com/dthree/vorpal/issues/199

I meant to open up a second PR, but it ended up here as well so why not: https://github.com/dthree/vorpal/issues/198

It's just adding a simple prototype method on command so you can compose program options. [for example](https://github.com/ccorcos/doug/blob/master/packages/doug-app/cli/build.js#L9).