### PR TITLE
Fix falsy value check when parsing variadic args

### DIFF
--- a/dist/util.js
+++ b/dist/util.js
@@ -271,12 +271,12 @@ var util = {
       var passedArg = parsedArgs._[l];
       if (matchArg !== undefined) {
         valid = !valid ? false : validateArg(parsedArgs._[l], matchArg);
-        if (!valid) {
+        if (!valid || passedArg === undefined) {
           break;
         }
-        if (passedArg && matchArg.variadic === true) {
+        if (matchArg.variadic === true) {
           args[matchArg.name] = remainingArgs;
-        } else if (passedArg !== undefined) {
+        } else {
           args[matchArg.name] = passedArg;
           remainingArgs.shift();
         }

--- a/dist/util.js
+++ b/dist/util.js
@@ -271,14 +271,16 @@ var util = {
       var passedArg = parsedArgs._[l];
       if (matchArg !== undefined) {
         valid = !valid ? false : validateArg(parsedArgs._[l], matchArg);
-        if (!valid || passedArg === undefined) {
+        if (!valid) {
           break;
         }
-        if (matchArg.variadic === true) {
-          args[matchArg.name] = remainingArgs;
-        } else {
-          args[matchArg.name] = passedArg;
-          remainingArgs.shift();
+        if (passedArg !== undefined) {
+          if (matchArg.variadic === true) {
+            args[matchArg.name] = remainingArgs;
+          } else {
+            args[matchArg.name] = passedArg;
+            remainingArgs.shift();
+          }
         }
       }
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -267,14 +267,16 @@ const util = {
       const passedArg = parsedArgs._[l];
       if (matchArg !== undefined) {
         valid = (!valid) ? false : validateArg(parsedArgs._[l], matchArg);
-        if (!valid || passedArg === undefined) {
+        if (!valid) {
           break;
         }
-        if (matchArg.variadic === true) {
-          args[matchArg.name] = remainingArgs;
-        } else {
-          args[matchArg.name] = passedArg;
-          remainingArgs.shift();
+        if (passedArg !== undefined) {
+          if (matchArg.variadic === true) {
+            args[matchArg.name] = remainingArgs;
+          } else {
+            args[matchArg.name] = passedArg;
+            remainingArgs.shift();
+          }
         }
       }
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -267,12 +267,12 @@ const util = {
       const passedArg = parsedArgs._[l];
       if (matchArg !== undefined) {
         valid = (!valid) ? false : validateArg(parsedArgs._[l], matchArg);
-        if (!valid) {
+        if (!valid || passedArg === undefined) {
           break;
         }
-        if (passedArg && matchArg.variadic === true) {
+        if (matchArg.variadic === true) {
           args[matchArg.name] = remainingArgs;
-        } else if (passedArg !== undefined) {
+        } else {
           args[matchArg.name] = passedArg;
           remainingArgs.shift();
         }

--- a/test/integration.js
+++ b/test/integration.js
@@ -462,6 +462,32 @@ describe('integration tests:', function () {
         });
       });
 
+      context('when first variadic argument has falsy value', function () {
+        context('when variadic argument comes last', function () {
+          it('should parse variadic arguments properly', function (done) {
+            exec('variadic pepperoni 0 1 olives ', done, function (err, data) {
+              (err === undefined).should.be.true;
+              data.pizza.should.equal('pepperoni');
+              data.ingredients[0].should.equal(0);
+              data.ingredients[1].should.equal(1);
+              data.ingredients[2].should.equal('olives');
+              done();
+            });
+          });
+        })
+        context('when one and only argument is variadic', function () {
+          it('should parse variadic arguments properly', function (done) {
+            exec('variadic-pizza 0 1 olives ', done, function (err, data) {
+              (err === undefined).should.be.true;
+              data.ingredients[0].should.equal(0);
+              data.ingredients[1].should.equal(1);
+              data.ingredients[2].should.equal('olives');
+              done();
+            });
+          });
+        })
+      })
+
       it('should accept a lot of arguments', function (done) {
         exec('cmd that has a ton of arguments', done, function (err, data) {
           (err === undefined).should.be.true;


### PR DESCRIPTION
Should fix #218 

Currently check `if (passedArg && matchArg.variadic === true)` fails when first variadic argument value is `0` (zero), because it has falsy value and boolean check of `passedArg` fails.