### PR TITLE
Add descriptors support: title, version, banner

### DIFF
--- a/dist/ui.js
+++ b/dist/ui.js
@@ -68,6 +68,7 @@ var UI = function (_EventEmitter) {
     _this._sigintCount = 0;
     _this._sigint = function () {
       if (_this._sigintCount > 1) {
+        _this.parent.emit('vorpal_exit');
         process.exit(0);
       } else {
         var text = _this.input();
@@ -141,7 +142,7 @@ var UI = function (_EventEmitter) {
       var render = inquirer.prompt.prompts[promptType].prototype.render;
       inquirer.prompt.prompts[promptType].prototype.render = function () {
         self._activePrompt = this;
-        return render.call(this);
+        return render.apply(this, arguments);
       };
     };
 

--- a/dist/util.js
+++ b/dist/util.js
@@ -426,6 +426,18 @@ var util = {
     return str + Array(len + 1).join(delimiter);
   },
 
+  /**
+   * Pad a row on the start and end with spaces.
+   *
+   * @param {String} str
+   * @return {String}
+   */
+  padRow: function padRow(str) {
+    return str.split('\n').map(function (row) {
+      return '  ' + row + '  ';
+    }).join('\n');
+  },
+
   // When passing down applied args, we need to turn
   // them from `{ '0': 'foo', '1': 'bar' }` into ['foo', 'bar']
   // instead.

--- a/dist/vorpal.js
+++ b/dist/vorpal.js
@@ -46,8 +46,8 @@ function Vorpal() {
   // Exposed through vorpal.version(str);
   this._version = '';
 
-  // Program name
-  this._name = '';
+  // Program title
+  this._title = '';
 
   // Program description
   this._description = '';
@@ -197,15 +197,15 @@ vorpal.version = function (version) {
 };
 
 /**
- * Sets the name of your application.
+ * Sets the title of your application.
  *
- * @param {String} name
+ * @param {String} title
  * @return {Vorpal}
  * @api public
  */
 
-vorpal.name = function (name) {
-  this._name = name;
+vorpal.title = function (title) {
+  this._title = title;
   return this;
 };
 
@@ -1186,14 +1186,14 @@ vorpal._helpHeader = function (hideTitle) {
   }
 
   // Only show under specific conditions
-  if (this._name && !hideTitle) {
-    var name = this._name;
+  if (this._title && !hideTitle) {
+    var title = this._title;
 
     if (this._version) {
-      name += ' v' + this._version;
+      title += ' v' + this._version;
     }
 
-    header.push(VorpalUtil.padRow(name));
+    header.push(VorpalUtil.padRow(title));
 
     if (this._description) {
       var descWidth = process.stdout.columns * 0.75; // Only 75% of the screen

--- a/dist/vorpal.js
+++ b/dist/vorpal.js
@@ -1173,9 +1173,42 @@ vorpal._commandHelp = function (command) {
 
   var groupsString = groups.length < 1 ? '' : '  Command Groups:\n\n' + groups.join('\n') + '\n';
 
-  var results = String(invalidString + commandsString + '\n' + groupsString).replace(/\n\n\n/g, '\n\n').replace(/\n\n$/, '\n');
+  var results = String(this._helpHeader(!!invalidString) + invalidString + commandsString + '\n' + groupsString).replace(/\n\n\n/g, '\n\n').replace(/\n\n$/, '\n');
 
   return results;
+};
+
+vorpal._helpHeader = function (hideTitle) {
+  var header = [];
+
+  if (this._banner) {
+    header.push(VorpalUtil.padRow(this._banner), '');
+  }
+
+  // Only show under specific conditions
+  if (this._name && !hideTitle) {
+    var name = this._name;
+
+    if (this._version) {
+      name += ' v' + this._version;
+    }
+
+    header.push(VorpalUtil.padRow(name));
+
+    if (this._description) {
+      var descWidth = process.stdout.columns * 0.75; // Only 75% of the screen
+
+      header.push(VorpalUtil.padRow(wrap(this._description, descWidth)));
+    }
+  }
+
+  // Pad the top and bottom
+  if (header.length) {
+    header.unshift('');
+    header.push('');
+  }
+
+  return header.join('\n');
 };
 
 /**

--- a/dist/vorpal.js
+++ b/dist/vorpal.js
@@ -46,6 +46,15 @@ function Vorpal() {
   // Exposed through vorpal.version(str);
   this._version = '';
 
+  // Program name
+  this._name = '';
+
+  // Program description
+  this._description = '';
+
+  // Program baner
+  this._banner = '';
+
   // Command line history instance
   this.cmdHistory = new this.CmdHistoryExtension();
 
@@ -184,6 +193,45 @@ Vorpal.prototype.parse = function (argv, options) {
 
 vorpal.version = function (version) {
   this._version = version;
+  return this;
+};
+
+/**
+ * Sets the name of your application.
+ *
+ * @param {String} name
+ * @return {Vorpal}
+ * @api public
+ */
+
+vorpal.name = function (name) {
+  this._name = name;
+  return this;
+};
+
+/**
+ * Sets the description of your application.
+ *
+ * @param {String} description
+ * @return {Vorpal}
+ * @api public
+ */
+
+vorpal.description = function (description) {
+  this._description = description;
+  return this;
+};
+
+/**
+ * Sets the banner of your application.
+ *
+ * @param {String} banner
+ * @return {Vorpal}
+ * @api public
+ */
+
+vorpal.banner = function (banner) {
+  this._banner = banner;
   return this;
 };
 
@@ -1229,6 +1277,7 @@ vorpal.getSessionById = function (id) {
 
 vorpal.exit = function (options) {
   var ssn = this.getSessionById(options.sessionId);
+  this.emit('vorpal_exit');
   if (ssn.isLocal()) {
     process.exit(0);
   } else {

--- a/examples/descriptors/descriptors.js
+++ b/examples/descriptors/descriptors.js
@@ -4,7 +4,7 @@ var vorpal = require('./../../')();
 var chalk = vorpal.chalk;
 
 vorpal
-  .name(chalk.magenta('Vorpal'))
+  .title(chalk.magenta('Vorpal'))
   .version('1.4.0')
   .description(chalk.cyan('Conquer the command-line.'))
   .banner(chalk.gray(`              (O)

--- a/examples/index/index.js
+++ b/examples/index/index.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var vorpal = require('./../../')();
+var chalk = vorpal.chalk;
+
+vorpal
+  .name(chalk.magenta('Vorpal'))
+  .version('1.4.0')
+  .description(chalk.cyan('Conquer the command-line.'))
+  .banner(chalk.gray(`              (O)
+              <M
+   o          <M
+  /| ......  /:M\\------------------------------------------------,,,,,,
+(O)[ vorpal ]::@+}==========================================------------>
+  \\| ^^^^^^  \\:W/------------------------------------------------''''''
+   o          <W
+              <W
+              (O)`));
+
+vorpal.command('build', 'Build the application.')
+  .option('-d')
+  .option('-a')
+  .action(function (args, cb) {
+    this.log(args);
+    cb();
+  });
+
+vorpal.command('clean', 'Clean the local workspace.')
+  .option('-f')
+  .action(function (args, cb) {
+    this.log(args);
+    cb();
+  });
+
+vorpal.command('compress', 'Compress assets.')
+  .option('-gzip')
+  .action(function (args, cb) {
+    this.log(args);
+    cb();
+  });
+
+vorpal
+  .catch('', 'Displays the index view.')
+  .action(function (args, cb) {
+    this.log(this.parent._commandHelp(args.command));
+    cb();
+  });
+
+vorpal
+  .delimiter('vorpal:')
+  .parse(process.argv);

--- a/lib/util.js
+++ b/lib/util.js
@@ -421,6 +421,18 @@ const util = {
     return str + Array(len + 1).join(delimiter);
   },
 
+  /**
+   * Pad a row on the start and end with spaces.
+   *
+   * @param {String} str
+   * @return {String}
+   */
+  padRow: function (str) {
+    return str.split('\n').map(function (row) {
+      return '  ' + row + '  ';
+    }).join('\n');
+  },
+
   // When passing down applied args, we need to turn
   // them from `{ '0': 'foo', '1': 'bar' }` into ['foo', 'bar']
   // instead.

--- a/lib/vorpal.js
+++ b/lib/vorpal.js
@@ -46,8 +46,8 @@ function Vorpal() {
   // Exposed through vorpal.version(str);
   this._version = '';
 
-  // Program name
-  this._name = '';
+  // Program title
+  this._title = '';
 
   // Program description
   this._description = '';
@@ -197,15 +197,15 @@ vorpal.version = function (version) {
 };
 
 /**
- * Sets the name of your application.
+ * Sets the title of your application.
  *
- * @param {String} name
+ * @param {String} title
  * @return {Vorpal}
  * @api public
  */
 
-vorpal.name = function (name) {
-  this._name = name;
+vorpal.title = function (title) {
+  this._title = title;
   return this;
 };
 
@@ -1186,7 +1186,12 @@ vorpal._commandHelp = function (command) {
     '' :
     '  Command Groups:\n\n' + groups.join('\n') + '\n';
 
-  var results = String(this._helpHeader(!!invalidString) + invalidString + commandsString + '\n' + groupsString)
+  var results = String(
+    this._helpHeader(!!invalidString) +
+    invalidString +
+    commandsString + '\n' +
+    groupsString
+  )
     .replace(/\n\n\n/g, '\n\n')
     .replace(/\n\n$/, '\n');
 
@@ -1201,14 +1206,14 @@ vorpal._helpHeader = function (hideTitle) {
   }
 
   // Only show under specific conditions
-  if (this._name && !hideTitle) {
-    var name = this._name;
+  if (this._title && !hideTitle) {
+    var title = this._title;
 
     if (this._version) {
-      name += ' v' + this._version;
+      title += ' v' + this._version;
     }
 
-    header.push(VorpalUtil.padRow(name));
+    header.push(VorpalUtil.padRow(title));
 
     if (this._description) {
       var descWidth = process.stdout.columns * 0.75; // Only 75% of the screen

--- a/lib/vorpal.js
+++ b/lib/vorpal.js
@@ -1186,9 +1186,44 @@ vorpal._commandHelp = function (command) {
     '' :
     '  Command Groups:\n\n' + groups.join('\n') + '\n';
 
-  var results = String(invalidString + commandsString + '\n' + groupsString).replace(/\n\n\n/g, '\n\n').replace(/\n\n$/, '\n');
+  var results = String(this._helpHeader(!!invalidString) + invalidString + commandsString + '\n' + groupsString)
+    .replace(/\n\n\n/g, '\n\n')
+    .replace(/\n\n$/, '\n');
 
   return results;
+};
+
+vorpal._helpHeader = function (hideTitle) {
+  var header = [];
+
+  if (this._banner) {
+    header.push(VorpalUtil.padRow(this._banner), '');
+  }
+
+  // Only show under specific conditions
+  if (this._name && !hideTitle) {
+    var name = this._name;
+
+    if (this._version) {
+      name += ' v' + this._version;
+    }
+
+    header.push(VorpalUtil.padRow(name));
+
+    if (this._description) {
+      var descWidth = process.stdout.columns * 0.75; // Only 75% of the screen
+
+      header.push(VorpalUtil.padRow(wrap(this._description, descWidth)));
+    }
+  }
+
+  // Pad the top and bottom
+  if (header.length) {
+    header.unshift('');
+    header.push('');
+  }
+
+  return header.join('\n');
 };
 
 /**

--- a/lib/vorpal.js
+++ b/lib/vorpal.js
@@ -46,6 +46,15 @@ function Vorpal() {
   // Exposed through vorpal.version(str);
   this._version = '';
 
+  // Program name
+  this._name = '';
+
+  // Program description
+  this._description = '';
+
+  // Program baner
+  this._banner = '';
+
   // Command line history instance
   this.cmdHistory = new this.CmdHistoryExtension();
 
@@ -184,6 +193,45 @@ Vorpal.prototype.parse = function (argv, options) {
 
 vorpal.version = function (version) {
   this._version = version;
+  return this;
+};
+
+/**
+ * Sets the name of your application.
+ *
+ * @param {String} name
+ * @return {Vorpal}
+ * @api public
+ */
+
+vorpal.name = function (name) {
+  this._name = name;
+  return this;
+};
+
+/**
+ * Sets the description of your application.
+ *
+ * @param {String} description
+ * @return {Vorpal}
+ * @api public
+ */
+
+vorpal.description = function (description) {
+  this._description = description;
+  return this;
+};
+
+/**
+ * Sets the banner of your application.
+ *
+ * @param {String} banner
+ * @return {Vorpal}
+ * @api public
+ */
+
+vorpal.banner = function (banner) {
+  this._banner = banner;
   return this;
 };
 

--- a/test/vorpal.js
+++ b/test/vorpal.js
@@ -7,6 +7,7 @@
 
 var Vorpal = require('../');
 var should = require('should');
+var assert = require('assert');
 var intercept = require('../dist/intercept');
 
 var vorpal;
@@ -346,5 +347,33 @@ describe('help menu', function () {
     help.execSync('cows')
     unmute();
     stdout.should.equal(fixture);
+  });
+});
+
+describe('metadata', function () {
+  var instance;
+
+  beforeEach(function () {
+    instance = Vorpal();
+  });
+
+  it('sets the version', function () {
+    instance.version('1.2.3');
+    assert.equal(instance._version, '1.2.3');
+  });
+
+  it('sets the name', function () {
+    instance.name('Vorpal');
+    assert.equal(instance._name, 'Vorpal');
+  });
+
+  it('sets the description', function () {
+    instance.description('A CLI tool.');
+    assert.equal(instance._description, 'A CLI tool.');
+  });
+
+  it('sets the banner', function () {
+    instance.banner('VORPAL');
+    assert.equal(instance._banner, 'VORPAL');
   });
 });

--- a/test/vorpal.js
+++ b/test/vorpal.js
@@ -350,7 +350,7 @@ describe('help menu', function () {
   });
 });
 
-describe('metadata', function () {
+describe('descriptors', function () {
   var instance;
 
   beforeEach(function () {
@@ -362,9 +362,9 @@ describe('metadata', function () {
     assert.equal(instance._version, '1.2.3');
   });
 
-  it('sets the name', function () {
-    instance.name('Vorpal');
-    assert.equal(instance._name, 'Vorpal');
+  it('sets the title', function () {
+    instance.title('Vorpal');
+    assert.equal(instance._title, 'Vorpal');
   });
 
   it('sets the description', function () {


### PR DESCRIPTION
Adds the ability to define a title, version, and banner for the vorpal instance. These descriptors will then be rendered when a help screen appears, for example:
<img width="464" alt="screen shot 2017-05-18 at 19 25 13" src="https://cloud.githubusercontent.com/assets/143744/26230737/fc1d333e-3bff-11e7-8f0a-a0daf1700e8d.png">

Satisfies part of this PR: https://github.com/dthree/vorpal/issues/224