### PR TITLE
Fixed crash when persisted history cannot be parsed

### DIFF
--- a/lib/history.js
+++ b/lib/history.js
@@ -38,7 +38,13 @@ class History {
     }
 
     // Load history from local storage
-    const persistedHistory = JSON.parse(this._localStorage.getItem(this._storageKey));
+    let persistedHistory = [];
+    try {
+      persistedHistory = JSON.parse(this._localStorage.getItem(this._storageKey));
+    } catch (error) {
+      // Nothing to do if the history cannot be parsed
+      // so just load an empty one, which is better than crashing.
+    }
     if (Array.isArray(persistedHistory)) {
       this._hist.push(...persistedHistory);
     }


### PR DESCRIPTION
Under some rare conditions, Vorpal can produce an invalid persisted history which, when loaded, would result in an uncaught exception that crashes the caller. To prevent this, the history is reset when invalid JSON is loaded.

Ideally whatever is causing the invalid JSON to be generated should also be fixed, but I couldn't replicate this. In my case, the JSON was fine *except* that there was an extra `]` at the end - so it would look like `["cmd1","cmd2","cmd3"]]`.