### PR TITLE
Added command option to disable type-casting

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -337,6 +337,14 @@ export default class Command extends EventEmitter {
   }
 
   /**
+   * Disables type casting for this command.
+   */
+  disableTypeCasting() {
+    this._disableTypeCasting = true;
+    return this;
+  }
+
+  /**
    * Returns the length of the longest option.
    */
   _largestOptionLength() {

--- a/lib/utils/buildCommandArgs.js
+++ b/lib/utils/buildCommandArgs.js
@@ -56,7 +56,7 @@ export default function buildCommandArgs(
     });
 
   // Use minimist to parse the args, and then build varidiac args and options.
-  const parsedArgs = parseArgs(passedArgs, types);
+  const parsedArgs = parseArgs(passedArgs, types, command._disableTypeCasting === true);
   const remainingArgs = [...parsedArgs._];
 
   // Builds varidiac args and options.

--- a/lib/utils/parseArgs.js
+++ b/lib/utils/parseArgs.js
@@ -8,7 +8,7 @@ const ARGS_PATTERN: RegExp = /"(.*?)"|'(.*?)'|`(.*?)`|([^\s"]+)/gi;
 /**
  * Parses command arguments from multiple sources.
  */
-export default function parseArgs(input: string, opts?: CLIParserOptions = {}): CLIArgs {
+export default function parseArgs(input: string, opts?: CLIParserOptions = {}, disableTypeCasting?: boolean = false): CLIArgs {
   let args = [];
   let match;
 
@@ -20,7 +20,29 @@ export default function parseArgs(input: string, opts?: CLIParserOptions = {}): 
     }
   } while (match !== null);
 
-  args = minimist(args, opts);
+  if (!opts.string) opts.string = [];
+  if (disableTypeCasting) opts.string.push('_');
+
+  let newArgs = minimist(args, opts);
+
+  if (disableTypeCasting) {
+    // Now that we have the full list of arguments in `newArgs`, disable type-casting
+    // for all of them by adding them to opts.string. Then run minimist a second
+    // time with this type casting disabled.
+    let doSecondPass = false;
+    for (let n in newArgs) {
+      if (!newArgs.hasOwnProperty(n)) continue;
+      if (opts.boolean && opts.boolean.indexOf(n) >= 0) continue;
+      if (n == '_') continue;
+      opts.string.push(n);
+      doSecondPass = true;
+    }
+
+    if (doSecondPass) newArgs = minimist(args, opts);
+  }
+
+  args = newArgs;
+
   args._ = args._ || [];
 
   return args;


### PR DESCRIPTION
By default, the underlying command parser package (minimist), converts strings that look like numbers to actual numbers. This causes all kind of problems since it's also going to randomly convert things like hashes to numbers.

For example, a hash like "a1ef" would result in "a1ef", but another hash like "93e8" would result in "9300000000". There are quite a few pull requests about this in the minimist package GitHub page, but unfortunately it's no longer maintained so it looks like it won't be fixed.

This pull request attempts to fix this in a way that preserves backward compatibility. It adds a command option `disableTypeCasting()` which, when used, disables type casting for all arguments and all flags for that command. If that option is not set, the code path is exactly the same so the applications that don't explicitly opt-in won't be affected.