### PR TITLE
Add .eslintignore file and ignore rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+flow-typed/**/*.js
+examples/**/*.js
+dist/**/*.js
+lib/**/*.js
+test/**/*.js


### PR DESCRIPTION
@milesj 

Are you open to adding an `.eslintignore` temporarily during the migration to ES6 so that eslint will not report errors for directories we have not migrated yet? We can remove the rules when we're finished.

I have editor integration enabled for eslint and all the lint errors in the old code are a little bit distracting :P