### PR TITLE
Explicit node_modules ignores in .flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,7 +2,7 @@
 ./src
 
 [ignore]
-.*/node_modules/.*
+.*/node_modules/eslint-plugin-jsx-a11y/.*
 .*/tests/.*
 .*\.test\.js
 


### PR DESCRIPTION
@milesj While migrating `lib/autocomplete.js`, flow was producing an error for not being able to find the `lodash` module.

This PR replaces the wildcard ignore with explicit ignores for specific modules that produce weird flow errors (right now it only appears `eslint-plugin-jsx-a11y` is causing issues). This allows flow to be able to detect the presence of installed modules for our dependencies.