### PR TITLE
Permit autocomplete options

### DIFF
--- a/dist/autocomplete.js
+++ b/dist/autocomplete.js
@@ -385,7 +385,7 @@ function getMatchData(input, cb) {
   var cmd = input.match;
   var midOption = String(string).trim().slice(0, 1) === '-';
   var afterOption = input.option !== undefined;
-  if (midOption === true) {
+  if (midOption === true && !cmd._allowUnknownOptions) {
     var results = [];
     for (var i = 0; i < cmd.options.length; ++i) {
       var long = cmd.options[i].long;

--- a/lib/autocomplete.js
+++ b/lib/autocomplete.js
@@ -393,7 +393,7 @@ function getMatchData(input, cb) {
   var cmd = input.match;
   var midOption = (String(string).trim().slice(0, 1) === '-');
   var afterOption = (input.option !== undefined);
-  if (midOption === true) {
+  if (midOption === true && (!cmd._allowUnknownOptions)) {
     var results = [];
     for (var i = 0; i < cmd.options.length; ++i) {
       var long = cmd.options[i].long;


### PR DESCRIPTION
So far user defined `autocomplete` function will not be called when trying to complete the arguments of a given options.

In case of `allowUnknownOptions`, it would be useful that the autocomplete function takes care of the flags completion. 

This is the need I have for building [vorpal-shell](https://github.com/AdrieanKhisbe/vorpal-shell) to have in cli completion of options.

Maybe other design option can be considered such as a property `handlesOption` in the `autocomplete` option along with the function `data`. I'm open to that :)