### PR TITLE
Normalization regex fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-  - "6"
-  - "8"
-  - "10"
+  - "node"
+  - "lts/*"
 sudo: false
 cache:
   directories:

--- a/lib/util.js
+++ b/lib/util.js
@@ -207,7 +207,7 @@ const util = {
     if(isCommandArgKeyPairNormalized) {
       // Normalize all foo="bar" with "foo='bar'"
       // This helps implement unix-like key value pairs.
-      const reg = /(['"]?)(\w+)=(?:(['"])((?:(?!\3).)*)\3|(\S+))\1/g;
+      const reg = /(?<=[-\s]\b)(\w+)=(["']\b)((?:(?=(\\?))\3.)*?)(?=\2)\2/g;
       passedArgs = passedArgs.replace(reg, `"$2='$4$5'"`);
     }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -208,7 +208,7 @@ const util = {
       // Normalize all foo="bar" with "foo='bar'"
       // This helps implement unix-like key value pairs.
       const reg = /(?<=[-\s]\b)(\w+)=(["']\b)((?:(?=(\\?))\3.)*?)(?=\2)\2/g;
-      passedArgs = passedArgs.replace(reg, `"$2='$4$5'"`);
+      passedArgs = passedArgs.replace(reg, `"$1='$3'"`);
     }
 
     // Types are custom arg types passed

--- a/test/vorpal.js
+++ b/test/vorpal.js
@@ -129,7 +129,7 @@ describe('argument parsing', function () {
     var fixture = obj({ options: {},
       req: "a='b'",
       opt: "c='d and e'",
-      variadic:  ["wombat='true'","a","fizz='buzz'","hello='goodbye'"] });
+      variadic:  ["wombat=true","a","fizz='buzz'","hello='goodbye'"] });
     obj(vorpal.execSync('multiple a=\'b\' c="d and e" wombat=true a fizz=\'buzz\' "hello=\'goodbye\'"')).should.equal(fixture);
   });
 


### PR DESCRIPTION
Handle the commandArgKeyPair normalization checking if the key=pair is not inside a string, also leaves untouched the key=pair strings that are not enclosed in quotes (both single/double)

As seen in the issue #307, this is the behavior now:
![image](https://user-images.githubusercontent.com/29862596/43196547-9098a6bc-9008-11e8-9300-6d84cf3231ae.png)

This is the proposed regex with the solution and some parse examples:

![image](https://user-images.githubusercontent.com/29862596/43196332-d56b91ce-9007-11e8-948b-b20fc5271f32.png)